### PR TITLE
promql: inject zero if there is only one point

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -147,6 +147,14 @@ func extendedRate(vals []parser.Value, args parser.Expressions, enh *EvalNodeHel
 	)
 
 	points := samples.Points
+
+	if len(points) == 1 {
+		injectedT := points[0].T - 1
+		if injectedT < 0 {
+			injectedT = 0
+		}
+		points = append([]Point{{T: injectedT, V: 0}}, points...)
+	}
 	if len(points) < 2 {
 		return enh.Out
 	}

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -127,6 +127,19 @@ eval instant at 49s xrate(http_requests[10s])
   {path="/foo"} .1
   {path="/bar"} 0.2
 
+# xincrease injects a zero if there is only one sample in the given timerange.
+eval instant at 1s xincrease(http_requests[5s])
+  {path="/foo"} 1
+  {path="/bar"} 1
+
+
+
+# xincrease does not inject anything at the end of the given timerange if there are
+# two or more samples.
+eval instant at 55s xincrease(http_requests[10s])
+  {path="/foo"} 0
+  {path="/bar"} 1
+
 clear
 
 


### PR DESCRIPTION
Extend xrate/xincrease/xdelta by injecting a zero if there is only one
point in the given timerange. This should emulate VM behaviour.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
