### PR TITLE
promql: make xincrease follow VM's definition

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -978,7 +978,6 @@ type EvalNodeHelper struct {
 	resultMetric map[string]labels.Labels
 
 	metricAppeared int64
-	seriesName     string
 }
 
 // DropMetricName is a cached version of DropMetricName.
@@ -1370,17 +1369,8 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 					}
 				}
 
-				// mint is ev.startTimestamp - 4 * 24 * time.Hour
-				// to include more points.
 				maxt := ts - offset
-
-				var mint int64
-				// Initially buffer +4 days for xincrease.
-				if step == 0 && e.Func.Name == "xincrease" {
-					mint = ev.startTimestamp - durationMilliseconds(4*24*time.Hour)
-				} else {
-					mint = maxt - selRange
-				}
+				mint := maxt - selRange
 
 				var metricAppeared int64 = -1
 				// Evaluate the matrix selector for this series for this step.
@@ -1396,8 +1386,6 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 				inMatrix[0].Points = points
 				enh.Ts = ts
 				// Make the function call.
-				enh.seriesName = s.Labels().String()
-
 				outVec := call(inArgs, e.Args, enh)
 				enh.Out = outVec[:0]
 				if len(outVec) > 0 {

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1384,24 +1384,13 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 
 				var metricAppeared int64 = -1
 				// Evaluate the matrix selector for this series for this step.
-				points = ev.matrixIterSlice(it, mint, maxt, e.Func.ExtRange, points, &metricAppeared)
+				points = ev.matrixIterSlice(it, mint, maxt, e.Func.ExtRange, points, &metricAppeared, e.Func.Name)
 				if len(points) == 0 {
 					enh.metricAppeared = -1
 					continue
 				}
 				if enh.metricAppeared == -1 && metricAppeared != -1 {
 					enh.metricAppeared = metricAppeared
-				}
-
-				// Include at least one point outside of the range.
-				if e.Func.Name == "xincrease" {
-					until := maxt - selRange
-					for pi := len(points) - 1; pi >= 0; pi-- {
-						if points[pi].T < until {
-							points = points[pi:]
-							break
-						}
-					}
 				}
 
 				inMatrix[0].Points = points
@@ -1415,7 +1404,9 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 					ss.Points = append(ss.Points, Point{V: outVec[0].Point.V, T: ts})
 				}
 				// Only buffer stepRange milliseconds from the second step on.
-				it.ReduceDelta(stepRange)
+				if e.Func.Name != "xincrease" {
+					it.ReduceDelta(stepRange)
+				}
 			}
 			if len(ss.Points) > 0 {
 				if ev.currentSamples+len(ss.Points) <= ev.maxSamples {
@@ -1776,7 +1767,7 @@ func (ev *evaluator) matrixSelector(node *parser.MatrixSelector) (Matrix, storag
 			Metric: series[i].Labels(),
 		}
 
-		ss.Points = ev.matrixIterSlice(it, mint, maxt, false, getPointSlice(16), nil)
+		ss.Points = ev.matrixIterSlice(it, mint, maxt, false, getPointSlice(16), nil, "")
 
 		if len(ss.Points) > 0 {
 			matrix = append(matrix, ss)
@@ -1795,8 +1786,14 @@ func (ev *evaluator) matrixSelector(node *parser.MatrixSelector) (Matrix, storag
 // values). Any such points falling before mint are discarded; points that fall
 // into the [mint, maxt] range are retained; only points with later timestamps
 // are populated from the iterator.
-func (ev *evaluator) matrixIterSlice(it *storage.BufferedSeriesIterator, mint, maxt int64, extRange bool, out []Point, metricAppeared *int64) []Point {
-	extMint := mint - durationMilliseconds(ev.lookbackDelta)
+func (ev *evaluator) matrixIterSlice(it *storage.BufferedSeriesIterator, mint, maxt int64, extRange bool, out []Point, metricAppeared *int64, functionName string) []Point {
+	var extMint int64
+	if functionName == "xincrease" {
+		extMint = mint - durationMilliseconds(4*24*time.Hour)
+	} else {
+		extMint = mint - durationMilliseconds(ev.lookbackDelta)
+	}
+
 	if len(out) > 0 && out[len(out)-1].T >= mint {
 		// There is an overlap between previous and current ranges, retain common
 		// points. In most such cases:

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -170,14 +170,17 @@ func extendedRate(vals []parser.Value, args parser.Expressions, enh *EvalNodeHel
 	averageInterval := sampledRange / float64(len(points)-1)
 
 	firstPoint := 0
-	// If the point before the range is too far from rangeStart, drop it.
-	if float64(rangeStart-points[0].T) > averageInterval {
-		if len(points) < 3 {
-			return enh.Out
+	// Only do this for not xincrease.
+	if !(isCounter && !isRate) {
+		// If the point before the range is too far from rangeStart, drop it.
+		if float64(rangeStart-points[0].T) > averageInterval {
+			if len(points) < 3 {
+				return enh.Out
+			}
+			firstPoint = 1
+			sampledRange = float64(points[len(points)-1].T - points[1].T)
+			averageInterval = sampledRange / float64(len(points)-2)
 		}
-		firstPoint = 1
-		sampledRange = float64(points[len(points)-1].T - points[1].T)
-		averageInterval = sampledRange / float64(len(points)-2)
 	}
 
 	var (
@@ -201,9 +204,13 @@ func extendedRate(vals []parser.Value, args parser.Expressions, enh *EvalNodeHel
 	// If the points cover the whole range (i.e. they start just before the
 	// range start and end just before the range end) adjust the value from
 	// the sampled range to the requested range.
-	if points[firstPoint].T <= rangeStart && durationToEnd < averageInterval {
-		adjustToRange := float64(durationMilliseconds(ms.Range))
-		resultValue = resultValue * (adjustToRange / sampledRange)
+	// Only do this for not xincrease.
+	if !(isCounter && !isRate) {
+		if points[firstPoint].T <= rangeStart && durationToEnd < averageInterval {
+			adjustToRange := float64(durationMilliseconds(ms.Range))
+			resultValue = resultValue * (adjustToRange / sampledRange)
+		}
+
 	}
 
 	if isRate {


### PR DESCRIPTION
xincrease already has an extended range i.e. it includes a point before the time range however more data needs to be buffered to emulate VMs behavior in case of a gap. Since Prometheus only has a Select() call i.e. there is no way to lookup metrics metadata, choose 4 days as a safe buffering range. Also, inject a value if all of the provided values are the same and we are in range of `ms.Range` from the appearance of a metric after a gap. Finally, make adjustments to the function so that it wouldn't drop the first point && do not adjust the value to the whole time range. Otherwise, the results could be weird.