### PR TITLE
api: add count_only option to /api/v1/series

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -765,6 +765,22 @@ func (api *API) series(r *http.Request) (result apiFuncResult) {
 	}
 
 	set := storage.NewMergeSeriesSet(sets, storage.ChainedSeriesMerge)
+
+	if r.Form.Get("only_count") == "1" {
+		var count uint64
+
+		for set.Next() {
+			count++
+		}
+
+		warnings := set.Warnings()
+		if set.Err() != nil {
+			return apiFuncResult{nil, &apiError{errorExec, set.Err()}, warnings, closer}
+		}
+
+		return apiFuncResult{count, nil, warnings, closer}
+
+	}
 	metrics := []labels.Labels{}
 	for set.Next() {
 		metrics = append(metrics, set.At().Labels())

--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -713,6 +713,10 @@ var (
 	maxTimeFormatted = maxTime.Format(time.RFC3339Nano)
 )
 
+type seriesOnlyCountResult struct {
+	MetricsCount uint64 `json:"metrics_count"`
+}
+
 func (api *API) series(r *http.Request) (result apiFuncResult) {
 	if err := r.ParseForm(); err != nil {
 		return apiFuncResult{nil, &apiError{errorBadData, errors.Wrapf(err, "error parsing form values")}, nil, nil}
@@ -778,7 +782,7 @@ func (api *API) series(r *http.Request) (result apiFuncResult) {
 			return apiFuncResult{nil, &apiError{errorExec, set.Err()}, warnings, closer}
 		}
 
-		return apiFuncResult{count, nil, warnings, closer}
+		return apiFuncResult{seriesOnlyCountResult{MetricsCount: count}, nil, warnings, closer}
 
 	}
 	metrics := []labels.Labels{}
@@ -1668,11 +1672,12 @@ func marshalPointJSONIsEmpty(ptr unsafe.Pointer) bool {
 }
 
 // marshalExemplarJSON writes.
-// {
-//    labels: <labels>,
-//    value: "<string>",
-//    timestamp: <float>
-// }
+//
+//	{
+//	   labels: <labels>,
+//	   value: "<string>",
+//	   timestamp: <float>
+//	}
 func marshalExemplarJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	p := *((*exemplar.Exemplar)(ptr))
 	stream.WriteObjectStart()

--- a/web/api/v1/api_test.go
+++ b/web/api/v1/api_test.go
@@ -942,6 +942,14 @@ func testEndpoints(t *testing.T, api *API, tr *testTargetRetriever, es storage.E
 		{
 			endpoint: api.series,
 			query: url.Values{
+				"match[]":    []string{`test_metric2`},
+				"only_count": []string{"1"},
+			},
+			response: uint64(1),
+		},
+		{
+			endpoint: api.series,
+			query: url.Values{
 				"match[]": []string{`{foo=""}`},
 			},
 			errType: errorBadData,


### PR DESCRIPTION
Add a count_only option so that it would be possible to count how many series are matched by given matchers. Idea is to call this from Sidecar before actually trying to execute the given call.

Example API output:
```
{"status":"success","data":5}
```

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
