### PR TITLE
reset frameBytesLeft after writing (#11689)

### DIFF
--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -204,10 +204,11 @@ func StreamChunkedReadResponses(
 		iter := series.Iterator()
 		lbls = MergeLabels(labelsToLabelsProto(series.Labels(), lbls), sortedExternalLabels)
 
-		frameBytesLeft := maxBytesInFrame
+		maxDataLength := maxBytesInFrame
 		for _, lbl := range lbls {
-			frameBytesLeft -= lbl.Size()
+			maxDataLength -= lbl.Size()
 		}
+		frameBytesLeft := maxDataLength
 
 		isNext := iter.Next()
 
@@ -253,6 +254,7 @@ func StreamChunkedReadResponses(
 			// We immediately flush the Write() so it is safe to return to the pool.
 			marshalPool.Put(&b)
 			chks = chks[:0]
+			frameBytesLeft = maxDataLength
 		}
 		if err := iter.Err(); err != nil {
 			return ss.Warnings(), err


### PR DESCRIPTION
Port a fix from https://github.com/prometheus/prometheus/pull/11689 to our fork. It should significantly improve Sidecar performance because there will be less write() calls. Local tests show about 60% improvement in throughput of requests that get small amount of data.



